### PR TITLE
[WIP] Compoud Authorizers + Extras

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -353,6 +353,7 @@ FOAM_FILES([
   // Auth Mixins
   { name: "foam/nanos/auth/CreatedAwareMixin" },
   { name: "foam/nanos/auth/CreatedByAwareMixin" },
+  { name: "foam/nanos/auth/AssignedToAwareMixin" },
   { name: "foam/nanos/auth/LastModifiedAwareMixin" },
   { name: "foam/nanos/auth/LastModifiedByAwareMixin" },
   { name: "foam/nanos/auth/LastModifiedByAgentNameAware" },

--- a/src/foam/nanos/auth/AssignedToAuthorizer.java
+++ b/src/foam/nanos/auth/AssignedToAuthorizer.java
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package foam.nanos.auth;
 
 import foam.core.FObject;

--- a/src/foam/nanos/auth/AssignedToAuthorizer.java
+++ b/src/foam/nanos/auth/AssignedToAuthorizer.java
@@ -1,0 +1,26 @@
+package foam.nanos.auth;
+
+import foam.core.FObject;
+import foam.core.X;
+
+public class AssignedToAuthorizer extends StandardAuthorizer {
+
+  public AssignedToAuthorizer(String permissionPrefix) {
+    super(permissionPrefix);
+  }
+
+  @Override
+  public void authorizeOnRead(X x, FObject obj) throws AuthorizationException {
+    if ( obj instanceof AssignedToAware ) {
+      final var ata = (AssignedToAware) obj;
+
+      final var subject = x.get(Subject.class);
+      if ( subject != null && subject.getUser() != null ) {
+        if ( subject.getUser().getId() == ata.getAssignedTo() )
+          return;
+      }
+    }
+
+    super.authorizeOnRead(x, obj);
+  }
+}

--- a/src/foam/nanos/auth/AssignedToAuthorizer.java
+++ b/src/foam/nanos/auth/AssignedToAuthorizer.java
@@ -14,7 +14,7 @@ public class AssignedToAuthorizer extends StandardAuthorizer {
     if ( obj instanceof AssignedToAware ) {
       final var ata = (AssignedToAware) obj;
 
-      final var subject = x.get(Subject.class);
+      final var subject = (Subject) x.get("subject");
       if ( subject != null && subject.getUser() != null ) {
         if ( subject.getUser().getId() == ata.getAssignedTo() )
           return;

--- a/src/foam/nanos/auth/AssignedToAware.js
+++ b/src/foam/nanos/auth/AssignedToAware.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+ foam.INTERFACE({
+  package: 'foam.nanos.auth',
+  name: 'AssignedToAware',
+
+  properties: [
+    {
+      class: 'Reference',
+      of: 'foam.nanos.auth.User',
+      name: 'assignedTo'
+    },
+    {
+      class: 'Reference',
+      of: 'foam.nanos.auth.Group',
+      name: 'assignedToGroup'
+    }
+  ]
+});

--- a/src/foam/nanos/auth/AssignedToAwareMixin.js
+++ b/src/foam/nanos/auth/AssignedToAwareMixin.js
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+ foam.CLASS({
+  package: 'foam.nanos.auth',
+  name: 'AssignedToAwareMixin',
+
+  implements: [
+    'foam.nanos.auth.AssignedToAware'
+  ],
+
+  properties: [
+    {
+      class: 'Reference',
+      of: 'foam.nanos.auth.User',
+      name: 'assignedTo'
+    },
+    {
+      class: 'Reference',
+      of: 'foam.nanos.auth.Group',
+      name: 'assignedToGroup'
+    }
+  ]
+});

--- a/src/foam/nanos/auth/CompoundAndAuthorizer.java
+++ b/src/foam/nanos/auth/CompoundAndAuthorizer.java
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.nanos.auth;
+
+import foam.core.FObject;
+import foam.core.X;
+import foam.mlang.predicate.Predicate;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+public class CompoundAndAuthorizer implements Authorizer {
+
+  protected Authorizer[] authorizers_;
+
+  public CompoundAndAuthorizer(Authorizer[] authorizers) {
+    authorizers_ = authorizers;
+  }
+
+  // Shortcut for testing all authorizers
+  protected void consume(Consumer<Authorizer> c) throws foam.nanos.auth.AuthorizationException {
+    for ( final var authorizer : authorizers_ )
+        c.accept(authorizer);
+  }
+
+  public void authorizeOnCreate(X x, FObject obj) throws AuthorizationException {
+    consume(authorizer -> authorizer.authorizeOnCreate(x, obj));
+  }
+
+  public void authorizeOnRead(X x, FObject obj) throws AuthorizationException {
+    consume(authorizer -> authorizer.authorizeOnRead(x, obj));
+  }
+
+  public void authorizeOnUpdate(X x, FObject oldObj, FObject newObj) throws AuthorizationException {
+    consume(authorizer -> authorizer.authorizeOnUpdate(x, oldObj, newObj));
+  }
+
+  public void authorizeOnDelete(X x, FObject obj) throws AuthorizationException {
+    consume(authorizer -> authorizer.authorizeOnDelete(x, obj));
+  }
+
+  public boolean checkGlobalRead(X x, Predicate predicate) {
+    return Arrays.stream(authorizers_).allMatch(authorizer -> checkGlobalRead(x, predicate));
+  }
+
+  public boolean checkGlobalRemove(X x) {
+    return Arrays.stream(authorizers_).allMatch(authorizer -> checkGlobalRemove(x));
+  }
+}

--- a/src/foam/nanos/auth/CompoundOrAuthorizer.java
+++ b/src/foam/nanos/auth/CompoundOrAuthorizer.java
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.nanos.auth;
+
+import foam.core.FObject;
+import foam.core.X;
+import foam.mlang.predicate.Predicate;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+public class CompoundOrAuthorizer implements Authorizer {
+
+  protected Authorizer[] authorizers_;
+
+  public CompoundOrAuthorizer(Authorizer[] authorizers) {
+    authorizers_ = authorizers;
+  }
+
+  // Shortcut for testing all authorizers
+  protected void consume(Consumer<Authorizer> c) throws foam.nanos.auth.AuthorizationException {
+    for ( final var authorizer : authorizers_ ) {
+      try {
+        c.accept(authorizer);
+      } catch(Exception ignored) {
+        continue;
+      }
+      return;
+    }
+    throw new AuthorizationException();
+  }
+
+  public void authorizeOnCreate(X x, FObject obj) throws AuthorizationException {
+    consume(authorizer -> authorizer.authorizeOnCreate(x, obj));
+  }
+
+  public void authorizeOnRead(X x, FObject obj) throws AuthorizationException {
+    consume(authorizer -> authorizer.authorizeOnRead(x, obj));
+  }
+
+  public void authorizeOnUpdate(X x, FObject oldObj, FObject newObj) throws AuthorizationException {
+    consume(authorizer -> authorizer.authorizeOnUpdate(x, oldObj, newObj));
+  }
+
+  public void authorizeOnDelete(X x, FObject obj) throws AuthorizationException {
+    consume(authorizer -> authorizer.authorizeOnDelete(x, obj));
+  }
+
+  public boolean checkGlobalRead(X x, Predicate predicate) {
+    return Arrays.stream(authorizers_).anyMatch(authorizer -> checkGlobalRead(x, predicate));
+  }
+
+  public boolean checkGlobalRemove(X x) {
+    return Arrays.stream(authorizers_).anyMatch(authorizer -> checkGlobalRemove(x));
+  }
+}

--- a/src/foam/nanos/auth/CreatedByAuthorizer.java
+++ b/src/foam/nanos/auth/CreatedByAuthorizer.java
@@ -1,0 +1,26 @@
+package foam.nanos.auth;
+
+import foam.core.FObject;
+import foam.core.X;
+
+public class CreatedByAuthorizer extends StandardAuthorizer {
+
+  public CreatedByAuthorizer(String permissionPrefix) {
+    super(permissionPrefix);
+  }
+
+  @Override
+  public void authorizeOnRead(X x, FObject obj) throws AuthorizationException {
+    if ( obj instanceof CreatedByAware ) {
+      final var ata = (CreatedByAware) obj;
+
+      final var subject = x.get(Subject.class);
+      if ( subject != null && subject.getUser() != null ) {
+        if ( subject.getUser().getId() == ata.getCreatedBy() )
+          return;
+      }
+    }
+
+    super.authorizeOnRead(x, obj);
+  }
+}

--- a/src/foam/nanos/auth/CreatedByAuthorizer.java
+++ b/src/foam/nanos/auth/CreatedByAuthorizer.java
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package foam.nanos.auth;
 
 import foam.core.FObject;

--- a/src/foam/nanos/auth/CreatedByAuthorizer.java
+++ b/src/foam/nanos/auth/CreatedByAuthorizer.java
@@ -14,7 +14,7 @@ public class CreatedByAuthorizer extends StandardAuthorizer {
     if ( obj instanceof CreatedByAware ) {
       final var ata = (CreatedByAware) obj;
 
-      final var subject = x.get(Subject.class);
+      final var subject = (Subject) x.get("subject");
       if ( subject != null && subject.getUser() != null ) {
         if ( subject.getUser().getId() == ata.getCreatedBy() )
           return;

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -124,6 +124,7 @@ FOAM_FILES([
   { name: "foam/nanos/auth/ResetPassword" },
   { name: "foam/nanos/auth/RetrievePassword" },
   { name: "foam/nanos/auth/UpdatePassword" },
+  { name: "foam/nanos/auth/AssignedToAware" },
   { name: "foam/nanos/auth/CreatedByAware" },
   { name: "foam/nanos/auth/CreatedByAwareDAO" },
   { name: "foam/nanos/auth/Subject" },

--- a/src/foam/nanos/ticket/Ticket.js
+++ b/src/foam/nanos/ticket/Ticket.js
@@ -21,6 +21,10 @@ foam.CLASS({
     'foam.nanos.auth.ServiceProviderAware'
   ],
 
+  mixins: [
+    'foam.nanos.auth.AssignedToAwareMixin'
+  ],
+
   topics: [
     'finished',
     'throwError'

--- a/src/foam/nanos/ticket/Ticket.js
+++ b/src/foam/nanos/ticket/Ticket.js
@@ -13,16 +13,13 @@ foam.CLASS({
   implements: [
     'foam.core.Validatable',
     'foam.nanos.auth.Authorizable',
+    'foam.nanos.auth.AssignedToAware',
     'foam.nanos.auth.CreatedAware',
     'foam.nanos.auth.CreatedByAware',
     'foam.nanos.auth.AssignableAware',
     'foam.nanos.auth.LastModifiedAware',
     'foam.nanos.auth.LastModifiedByAware',
     'foam.nanos.auth.ServiceProviderAware'
-  ],
-
-  mixins: [
-    'foam.nanos.auth.AssignedToAwareMixin'
   ],
 
   topics: [

--- a/src/foam/nanos/ticket/services.jrl
+++ b/src/foam/nanos/ticket/services.jrl
@@ -62,6 +62,7 @@ p({
     return new foam.dao.EasyDAO.Builder(x)
       .setOf(foam.nanos.ticket.Ticket.getOwnClassInfo())
       .setAuthorize(true)
+      .setAuthorizer(new foam.nanos.auth.AssignedToAuthorizer("ticket"))
       .setEnableInterfaceDecorators(false)
       .setInnerDAO((foam.dao.DAO) x.get("localTicketDAO"))
       .build();

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -286,6 +286,7 @@ var classes = [
   'foam.nanos.auth.CheckPermissionsSink',
   'foam.nanos.auth.Group',
   'foam.nanos.auth.PasswordPolicy',
+  'foam.nanos.auth.AssignedToAware',
   'foam.nanos.auth.CreatedAware',
   'foam.nanos.auth.CreatedAwareDAO',
   'foam.nanos.auth.CreatedByAware',


### PR DESCRIPTION
Thoughts on AssignedToAware:  I created the `AssignedToAware` interface to allow the `AssignedToAuthorizer` to recognize that a model is assignable, but now I'm second guessing if just using `CreatedFor` is better...  Not sure, I think maybe `AssignedTo` is better in this case, so that once a ticket is unassigned to a person they can't see it anymore, thoughts @jlhughes ?  Possibly a `ModelPropertyAuthorizer` that authorizes any read op on a model such that `model.property == subject.user.id`, could be used for any of the `CreatedFor`, `CreatedBy`, `LastModifiedBy`, etc. interfaces we have.