### PR TITLE
fix status choices

### DIFF
--- a/src/foam/nanos/ticket/RfiTicket.js
+++ b/src/foam/nanos/ticket/RfiTicket.js
@@ -21,6 +21,20 @@ foam.CLASS({
 
   properties: [
     {
+      name: 'statusChoices',
+      hidden: true,
+      factory: function() {
+        var s = [];
+        s.push(this.status);
+        if ( this.status == 'OPEN' ) {
+          s.push('EXPIRED');
+          s.push('CLOSED');
+        }
+        return s;
+      },
+      documentation: 'Returns available statuses for each ticket depending on current status'
+    },
+    {
       name: 'type',
       value: 'Request for information',
       section: 'infoSection'


### PR DESCRIPTION
same as https://github.com/nanoPayinc/NANOPAY/pull/14513
* fix available status choices for rfi tickets

only added to `RfiTicket` because the `sessionToken` property is specific to `RfiTicket`

| current status | status choices        |
|----------------|-----------------------|
| Open           | Open, Expired, Closed |
| Expired        | Expired               |
| Closed         | Closed                |