### PR TITLE
mobile - suppress text transition, reduce padding slightly

### DIFF
--- a/src/foam/u2/dialog/ApplicationPopup.js
+++ b/src/foam/u2/dialog/ApplicationPopup.js
@@ -73,6 +73,11 @@ foam.CLASS({
       align-items: center;
       padding: 12px;
     }
+    @media only screen and (max-width: 767px) {
+      ^header {
+        padding: 6px;
+      }
+    }
     ^header.showBorder {
       border-bottom: 1px solid $grey300;
     }
@@ -134,6 +139,11 @@ foam.CLASS({
       flex-shrink: 0;
       white-space: nowrap;
     }
+    @media only screen and (max-width: 767px) {
+      ^footer {
+        padding: 0.3em 1em;
+      }
+    }
     ^footer-right, ^footer-left {
       display: flex;
       align-items: center;
@@ -158,11 +168,17 @@ foam.CLASS({
       text-align: center;
       transition: all 150ms;
     }
-
     ^inner-title-small {
       padding: 1.2rem 0;
     }
-
+    @media only screen and (max-width: 767px) {
+      ^inner-title, ^inner-title-small {
+        font-size: 1.6rem;
+        line-height: 1.25;
+        padding: 1.2rem 0;
+        transition: none;
+      }
+    }
     ^footer.p-legal-light {
       color: #6F6F6F;
     }


### PR DESCRIPTION
Reduce padding in header and footer. 
Suppress large to small text transition on mobile. 
<img width="425" alt="Screenshot 2023-05-17 at 2 51 12 PM" src="https://github.com/nanoPayinc/foam3/assets/684019/3315a036-8c57-4c78-838f-092cc2ca6f7b">
