### PR TITLE
Update GoogleChatSetting.js

### DIFF
--- a/src/foam/core/notification/GoogleChatSetting.js
+++ b/src/foam/core/notification/GoogleChatSetting.js
@@ -54,7 +54,6 @@ foam.CLASS({
           Map thread = new HashMap();
           thread.put("threadKey", threadKey.toString());
           map.put("thread", thread);
-          URL += "&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD";
         }
 
         String message = notification.getGoogleChatMessage();


### PR DESCRIPTION
1. Removed 'thread' logic in Google Chat (as the new UI is not thread friendly)